### PR TITLE
Update to support latest features.

### DIFF
--- a/fargate_task_validator/__main__.py
+++ b/fargate_task_validator/__main__.py
@@ -56,9 +56,9 @@ def display_results(results):
 def validate_task_definition(task_definition):
     try:
         validator.validate(task_definition)
-        return "Task definition is valid!"
+        return "Task definition schema is valid!"
     except ValidationError as e:
-        return f"Task definition is invalid! {e}"
+        return f"Task definition schema is invalid! {e}"
 
 
 def main():
@@ -71,11 +71,11 @@ def main():
     with open(task_definition_path, "r") as f:
         task_definition_str = f.read()
 
-    results = check_fargate_compatibility(task_definition_str)
-    display_results(results)
-
     result = validate_task_definition(json.loads(task_definition_str))
     print(result)
+
+    results = check_fargate_compatibility(task_definition_str)
+    display_results(results)
 
 
 if __name__ == "__main__":

--- a/fargate_task_validator/validators/recommendations.py
+++ b/fargate_task_validator/validators/recommendations.py
@@ -23,6 +23,8 @@ RECOMMENDATIONS = {
     "stopTimeout": "Ensure the stop timeout value in your task definition does not exceed the Fargate limit.",
     "GPU": "GPU configurations are not supported in Fargate.",
     "computing": "Ensure the computing configurations in your task definition are compatible with Fargate.",
+    "pidMode": "Ensure you're using a supported 'pidMode' for Fargate. Only 'task' is supported.",
+    "sysctl": "Ensure the sysctl parameters in your task definition are supported in Fargate.",
 }
 
 REMEDIATIONS = {
@@ -45,6 +47,8 @@ REMEDIATIONS = {
     "stopTimeout": "Adjust the 'stopTimeout' in your task definition to be within Fargate's limits.",
     "GPU": "Remove GPU configurations from your task definition.",
     "computing": "Ensure the computing settings in your task definition are Fargate-compatible.",
+    "pidMode": "Change the 'pidMode' in your task definition to 'task' for Fargate compatibility.",
+    "sysctl": "Adjust or remove unsupported sysctl parameters from your task definition.",
 }
 
 for param in UNSUPPORTED_CONTAINER_PARAMETERS + UNSUPPORTED_ROOT_PARAMETERS:


### PR DESCRIPTION
### Add Support for pidMode and sysctl in Fargate Compatibility Checks

#### Changes:
- Incorporated the recent support for `pidMode` and `sysctl` configurations in AWS Fargate into our compatibility checks.
- Updated recommendations and remediations dictionaries to provide guidance on these configurations.

#### Motivation:
With AWS Fargate's recent announcement of supporting `pidMode` and specific `sysctl` parameters, it's crucial for our compatibility checker to stay up-to-date. This ensures that users receive accurate feedback and recommendations when configuring their task definitions.

#### Testing:
- Ensure that task definitions with `pidMode` set to `task` pass the check.
- Validate that supported `sysctl` parameters do not raise any compatibility issues.

Feedback and further testing suggestions are appreciated.